### PR TITLE
Update throttle.dart

### DIFF
--- a/lib/src/throttle.dart
+++ b/lib/src/throttle.dart
@@ -30,7 +30,9 @@ class Throttling {
     _waiter
       ..then((_) {
         this._isReady = true;
-        this._stateSC.sink.add(true);
+        if (!_stateSC.isClosed) {
+          this._stateSC.sink.add(true);
+        }
       });
     return Function.apply(func, []);
   }


### PR DESCRIPTION
Resolve a bug that can throw "Bad state: Cannot add new events after calling close"